### PR TITLE
Stop skipping tests on the main branch

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -8,22 +8,7 @@ on:
   pull_request:
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    # map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
-        with:
-          skip_after_successful_duplicate: 'true'
-          paths_ignore: '["**/README.md"]'
-          do_not_skip: '["workflow_dispatch", "schedule"]'
-
   test:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     strategy:
       matrix:
         go-version: [1.14.x, 1.15.x]


### PR DESCRIPTION
Stop skipping tests on the main branch in order to accurately track the coverage.